### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ that adds a few shortcuts: `itervalues`, `test`, `add` and `remove`.
 [![pypi version](http://img.shields.io/pypi/v/marcx.svg?style=flat)](https://pypi.python.org/pypi/marcx)
 
 <!---
-[![PyPi version](https://pypip.in/v/marcx/badge.png)](https://crate.io/packages/marcx/)
+[![PyPi version](https://img.shields.io/pypi/v/marcx.svg)](https://crate.io/packages/marcx/)
 -->
 
 Since version 0.2.0, both Python 2 and 3 should be supported.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20marcx))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `marcx`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.