### PR TITLE
Introduce Python >=3.8.10 compatibility

### DIFF
--- a/marcx.py
+++ b/marcx.py
@@ -6,7 +6,10 @@ Few extensions on `pymarc.Record` to make certain checks
 and manipulations a bit easier.
 """
 
-import collections
+try:
+    from collections.abc import Iterable  # noqa
+except ImportError:
+    from collections import Iterable  # noqa
 import itertools
 import re
 import warnings
@@ -277,7 +280,7 @@ class Record(pymarc.Record):
                         if value == "":
                             continue
                         subfields += [key, value]
-                    elif isinstance(value, collections.Iterable):
+                    elif isinstance(value, Iterable):
                         for val in value:
                             if not isinstance(val, basestring):
                                 raise ValueError('subfield values must be strings')


### PR DESCRIPTION
by avoiding (always) importing collections ABCs with `import
collections`.

This is deprecated in recent Python versions:

> Deprecated since version 3.3, will be removed in version 3.10: Moved
Collections Abstract Base Classes to the collections.abc module.
For backwards compatibility, they continue to be visible in this
module through Python 3.9. [1]

Following the principle of least surprise [2] and without introducing
new incompatibilities that I'm aware of, collections should be still
importable with `import collections` (i.e. for Python 2.7).

For some more background about this exact issue, see [3].

[1] https://docs.python.org/3/library/collections.html
[2] https://en.wikipedia.org/wiki/Principle_of_least_astonishment
[3] https://stackoverflow.com/questions/53978542/how-to-use-collections-abc-from-both-python-3-8-and-python-2-7